### PR TITLE
Fix warning for deprecated rackspace_endpoint

### DIFF
--- a/lib/vagrant-rackspace/action/connect_rackspace.rb
+++ b/lib/vagrant-rackspace/action/connect_rackspace.rb
@@ -25,7 +25,7 @@ module VagrantPlugins
             :provider => :rackspace,
             :version  => :v2,
             :rackspace_api_key => api_key,
-            :rackspace_endpoint => endpoint,
+            :rackspace_compute_url => endpoint,
             :rackspace_username => username
           })
 


### PR DESCRIPTION
Just cleaning up the deprecation warning that occurs when using the Rackspace vagrant provider.
