### PR TITLE
Making updates related to fog api changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,10 @@ This provider exposes quite a few provider-specific configuration options:
 * `image` - The server image to boot. This can be a string matching the
   exact ID or name of the image, or this can be a regular expression to
   partially match some image.
-* `rackspace_region` - The region to hit. By default this is :dfw. Valid options are: :dfw, :ord, :lon
+* `rackspace_region` - The region to hit. By default this is :dfw. Valid options are: 
+:dfw, :ord, :lon.  User this OR rackspace_compute_url
+* `rackspace_compute_url` - The compute_url to hit. This is good for custom endpoints. 
+Use this OR rackspace_region.
 * `public_key_path` - The path to a public key to initialize with the remote
   server. This should be the matching pair for the private key configured
   with `config.ssh.private_key_path` on Vagrant.

--- a/lib/vagrant-rackspace/action/connect_rackspace.rb
+++ b/lib/vagrant-rackspace/action/connect_rackspace.rb
@@ -17,17 +17,27 @@ module VagrantPlugins
           # Get the configs
           config   = env[:machine].provider_config
           api_key  = config.api_key
-          rackspace_region = config.rackspace_region
           username = config.username
 
-          @logger.info("Connecting to Rackspace...")
-          env[:rackspace_compute] = Fog::Compute.new({
-            :provider => :rackspace,
-            :version  => :v2,
-            :rackspace_api_key => api_key,
-            :rackspace_region => rackspace_region,
-            :rackspace_username => username
-          })
+	  if config.rackspace_compute_url.nil? then
+	    @logger.info("Connecting to Rackspace region...")
+	    env[:rackspace_compute] = Fog::Compute.new({
+	      :provider => :rackspace,
+	      :version  => :v2,
+	      :rackspace_api_key => api_key,
+	      :rackspace_region => config.rackspace_region,
+	      :rackspace_username => username
+	    })
+          else
+	    @logger.info("Connecting to Rackspace compute_url...")
+	    env[:rackspace_compute] = Fog::Compute.new({
+	      :provider => :rackspace,
+	      :version  => :v2,
+	      :rackspace_api_key => api_key,
+	      :rackspace_compute_url => config.rackspace_compute_url,
+	      :rackspace_username => username
+	    })
+	  end
 
           @app.call(env)
         end

--- a/lib/vagrant-rackspace/config.rb
+++ b/lib/vagrant-rackspace/config.rb
@@ -14,7 +14,25 @@ module VagrantPlugins
       #
       # expected to be a symbol - :dfw (default), :ord, :lon
       #
+      # use this OR rackspace_compute_url
       attr_accessor :rackspace_region
+
+      # The compute_url to access RackSpace. If nil, it will default
+      # to DFW.
+      # (formerly know as 'endpoint')
+      #
+      # expected to be a string url - 
+      # 'https://dfw.servers.api.rackspacecloud.com/v2'
+      # 'https://ord.servers.api.rackspacecloud.com/v2'
+      # 'https://lon.servers.api.rackspacecloud.com/v2'
+      #
+      # alternatively, can use constants if you require 'fog/rackspace' in your Vagrantfile
+      # Fog::Compute::RackspaceV2::DFW_ENDPOINT
+      # Fog::Compute::RackspaceV2::ORD_ENDPOINT
+      # Fog::Compute::RackspaceV2::LON_ENDPOINT
+      #
+      # use this OR rackspace_region
+      attr_accessor :rackspace_compute_url
 
       # The flavor of server to launch, either the ID or name. This
       # can also be a regular expression to partially match a name.
@@ -43,6 +61,7 @@ module VagrantPlugins
       def initialize
         @api_key  = UNSET_VALUE
         @rackspace_region = UNSET_VALUE
+        @rackspace_compute_url = UNSET_VALUE
         @flavor   = UNSET_VALUE
         @image    = UNSET_VALUE
         @public_key_path = UNSET_VALUE
@@ -53,6 +72,7 @@ module VagrantPlugins
       def finalize!
         @api_key  = nil if @api_key == UNSET_VALUE
         @rackspace_region = nil if @rackspace_region == UNSET_VALUE
+        @rackspace_compute_url = nil if @rackspace_compute_url == UNSET_VALUE
         @flavor   = /512MB/ if @flavor == UNSET_VALUE
         @image    = /Ubuntu/ if @image == UNSET_VALUE
         @server_name = nil if @server_name == UNSET_VALUE

--- a/spec/vagrant-rackspace/config_spec.rb
+++ b/spec/vagrant-rackspace/config_spec.rb
@@ -12,6 +12,7 @@ describe VagrantPlugins::Rackspace::Config do
 
     its(:api_key)  { should be_nil }
     its(:rackspace_region) { should be_nil }
+    its(:rackspace_compute_url) { should be_nil }
     its(:flavor)   { should eq(/512MB/) }
     its(:image)    { should eq(/Ubuntu/) }
     its(:public_key_path) { should eql(vagrant_public_key) }
@@ -22,6 +23,7 @@ describe VagrantPlugins::Rackspace::Config do
   describe "overriding defaults" do
     [:api_key,
       :rackspace_region,
+      :rackspace_compute_url,
       :flavor,
       :image,
       :public_key_path,


### PR DESCRIPTION
If we try to use 'endpoint' or 'compute_url' it will just silently
default to dfw and never create anything in ord.

Changed instances of endpoint to rackspace_region to be consistent
with fog.

Note that a bit of the documentation refers to the :lon region, but
this is not useable without the ability to set the auth url. This
was addressed in https://github.com/mitchellh/vagrant-rackspace/pull/4
but that had a couple other changes as well.
