### PR TITLE
Fixes deprecated :rackspace_endpoint key.

### DIFF
--- a/lib/vagrant-rackspace/action/connect_rackspace.rb
+++ b/lib/vagrant-rackspace/action/connect_rackspace.rb
@@ -25,7 +25,7 @@ module VagrantPlugins
             :provider => :rackspace,
             :version  => :v2,
             :rackspace_api_key => api_key,
-            :rackspace_endpoint => endpoint,
+            :rackspace_compute_url => endpoint,
             :rackspace_username => username
           })
 


### PR DESCRIPTION
Was getting this output every time the plugin connected:

```
[DEPRECATION] The :rackspace_endpoint option is deprecated. Please use :rackspace_compute_url for custom endpoints
```

https://github.com/fog/fog/blob/master/lib/fog/rackspace/compute_v2.rb#L220-L227
