### PR TITLE
Use /cygdrive when rsyncing on Windows

### DIFF
--- a/lib/vagrant-rackspace/action/sync_folders.rb
+++ b/lib/vagrant-rackspace/action/sync_folders.rb
@@ -29,7 +29,7 @@ module VagrantPlugins
             
             # If on Windows, modify the path to work with cygwin rsync
             if @host_os =~ /mswin|mingw|cygwin/
-              hostpath = hostpath.sub("C:/", "/cygdrive/c/")
+              hostpath = hostpath.sub(/^([A-Za-z]):\//, "/cygdrive/#{$1.downcase}/")
             end
 
             env[:ui].info(I18n.t("vagrant_rackspace.rsync_folder",


### PR DESCRIPTION
Hi there,

I was trying to use the plugin on windows and it worked great until rsync failed:

"The source and destination cannot be both remote"

I'm using cygwin rsync by putting C:\cygwin\bin on my PATH. Changing hostpath to use /cygdrive/c rather than C:/ made rsync work.

This pull request is hard coded to the C drive, which I imagine could be an issue. If so, I'm happy to reconsider, maybe use a regex to replace the initial drive letter.

Still, opening this in case it is interesting.
