### PR TITLE
Make chown'ing of synced folder perms recursive (for ssh user)

### DIFF
--- a/lib/vagrant-rackspace/action/sync_folders.rb
+++ b/lib/vagrant-rackspace/action/sync_folders.rb
@@ -33,7 +33,7 @@ module VagrantPlugins
             # Create the guest path
             env[:machine].communicate.sudo("mkdir -p '#{guestpath}'")
             env[:machine].communicate.sudo(
-              "chown #{ssh_info[:username]} '#{guestpath}'")
+              "chown -R #{ssh_info[:username]} '#{guestpath}'")
 
             # Rsync over to the guest path using the SSH info
             command = [


### PR DESCRIPTION
I am using vagrant to set up team infrastructure (jenkins environments). I use a process where the first vagrant run actually turns off root login access for all subsequent runs, but prior to that, it adds a bunch of users for each team member, giving everyone sudo access. Subsequent vagrant runs are made by those users.

This `chown` needs to become `chown -R` so that this will work:
https://github.com/mitchellh/vagrant-rackspace/blob/0c436ec3274de71c0254a4bc2e9db248d474ed7a/lib/vagrant-rackspace/action/sync_folders.rb#L36

Otherwise, lots of stuff like this shows up with rsync:

```
There was an error when attemping to rsync a share folder.
Please inspect the error message below for more info.

Host path: /Users/patcon/repos/jenkins-inception/
Guest path: /vagrant
Error: rsync: failed to set times on "/vagrant/.git": Operation not permitted (1)
rsync: failed to set times on "/vagrant/cookbooks": Operation not permitted (1)
rsync: failed to set times on "/vagrant/cookbooks/apache2": Operation not permitted (1)
rsync: failed to set times on "/vagrant/cookbooks/apache2/attributes": Operation not permitted (1)
rsync: failed to set times on "/vagrant/cookbooks/apache2/definitions": Operation not permitted (1)

//...

rsync: mkstemp "/vagrant/cookbooks/chef_handler/.metadata.rb.qHlLFG" failed: Permission denied (13)
rsync: mkstemp "/vagrant/cookbooks/chef_handler/attributes/.default.rb.FzHki3" failed: Permission denied (13)
rsync: mkstemp "/vagrant/cookbooks/chef_handler/files/default/handlers/.README.1c1VUp" failed: Permission denied (13)
rsync: mkstemp "/vagrant/cookbooks/chef_handler/providers/.default.rb.bdHfAM" failed: Permission denied (13)
rsync: mkstemp "/vagrant/cookbooks/chef_handler/recipes/.default.rb.iD3Bf9" failed: Permission denied (13)

//...
```
