### PR TITLE
Updated to support multiple authentication endpoints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,11 @@ This provider exposes quite a few provider-specific configuration options:
   exact ID or name of the image, or this can be a regular expression to
   partially match some image.
 * `rackspace_region` - The region to hit. By default this is :dfw. Valid options are: 
-:dfw, :ord, :lon.  User this OR rackspace_compute_url
+:dfw, :ord, :lon, :iad, :syd.  Users should preference using this setting over `rackspace_compute_url` setting.
 * `rackspace_compute_url` - The compute_url to hit. This is good for custom endpoints. 
-Use this OR rackspace_region.
+* `rackspace_auth_url` - The endpoint to authentication against. By default, vagrant will use the global
+rackspace authentication endpoint for all regions with the exception of :lon. IF :lon region is specified
+vagrant will authenticate against the UK authentication endpoint.
 * `public_key_path` - The path to a public key to initialize with the remote
   server. This should be the matching pair for the private key configured
   with `config.ssh.private_key_path` on Vagrant.

--- a/lib/vagrant-rackspace/action/connect_rackspace.rb
+++ b/lib/vagrant-rackspace/action/connect_rackspace.rb
@@ -19,25 +19,23 @@ module VagrantPlugins
           api_key  = config.api_key
           username = config.username
 
-	  if config.rackspace_compute_url.nil? then
-	    @logger.info("Connecting to Rackspace region...")
-	    env[:rackspace_compute] = Fog::Compute.new({
-	      :provider => :rackspace,
-	      :version  => :v2,
-	      :rackspace_api_key => api_key,
-	      :rackspace_region => config.rackspace_region,
-	      :rackspace_username => username
-	    })
+          params = {
+            :provider => :rackspace,
+            :version  => :v2,
+            :rackspace_api_key => api_key,
+            :rackspace_username => username,
+            :rackspace_auth_url => config.rackspace_auth_url
+          }
+
+          if config.rackspace_compute_url
+            @logger.info("Connecting to Rackspace compute_url...")
+            params[:rackspace_compute_url] = config.rackspace_compute_url
           else
-	    @logger.info("Connecting to Rackspace compute_url...")
-	    env[:rackspace_compute] = Fog::Compute.new({
-	      :provider => :rackspace,
-	      :version  => :v2,
-	      :rackspace_api_key => api_key,
-	      :rackspace_compute_url => config.rackspace_compute_url,
-	      :rackspace_username => username
-	    })
-	  end
+            @logger.info("Connecting to Rackspace region...")
+            params[:rackspace_region] = config.rackspace_region
+          end
+
+          env[:rackspace_compute] = Fog::Compute.new params
 
           @app.call(env)
         end

--- a/spec/vagrant-rackspace/config_spec.rb
+++ b/spec/vagrant-rackspace/config_spec.rb
@@ -1,4 +1,5 @@
 require "vagrant-rackspace/config"
+require 'fog'
 
 describe VagrantPlugins::Rackspace::Config do
   describe "defaults" do
@@ -13,6 +14,7 @@ describe VagrantPlugins::Rackspace::Config do
     its(:api_key)  { should be_nil }
     its(:rackspace_region) { should be_nil }
     its(:rackspace_compute_url) { should be_nil }
+    its(:rackspace_auth_url) { should be_nil }
     its(:flavor)   { should eq(/512MB/) }
     its(:image)    { should eq(/Ubuntu/) }
     its(:public_key_path) { should eql(vagrant_public_key) }
@@ -25,6 +27,7 @@ describe VagrantPlugins::Rackspace::Config do
     [:api_key,
       :rackspace_region,
       :rackspace_compute_url,
+      :rackspace_auth_url,
       :flavor,
       :image,
       :public_key_path,
@@ -64,6 +67,55 @@ describe VagrantPlugins::Rackspace::Config do
 
     context "the username" do
       it "should error if not given"
+    end
+  end
+
+  describe "rackspace_auth_url" do
+    it "should return UNSET_VALUE if rackspace_auth_url and rackspace_region are UNSET" do
+      subject.rackspace_auth_url.should == VagrantPlugins::Rackspace::Config::UNSET_VALUE
+    end
+    it "should return UNSET_VALUE if rackspace_auth_url is UNSET and rackspace_region is :ord" do
+      subject.rackspace_region = :ord
+      subject.rackspace_auth_url.should == VagrantPlugins::Rackspace::Config::UNSET_VALUE
+    end
+    it "should return UK Authentication endpoint if rackspace_auth_url is UNSET and rackspace_region is :lon" do
+      subject.rackspace_region = :lon
+      subject.rackspace_auth_url.should == Fog::Rackspace::UK_AUTH_ENDPOINT
+    end
+    it "should return custom endpoint if supplied and rackspace_region is :lon" do
+      my_endpoint = 'http://custom-endpoint.com'
+      subject.rackspace_region = :lon
+      subject.rackspace_auth_url = my_endpoint
+      subject.rackspace_auth_url.should == my_endpoint
+    end
+    it "should return custom endpoint if supplied and rackspace_region is UNSET" do
+      my_endpoint = 'http://custom-endpoint.com'
+      subject.rackspace_auth_url = my_endpoint
+      subject.rackspace_auth_url.should == my_endpoint
+    end
+  end
+
+
+  describe "lon_region?" do
+    it "should return false if rackspace_region is UNSET_VALUE" do
+      subject.rackspace_region = VagrantPlugins::Rackspace::Config::UNSET_VALUE
+      subject.send(:lon_region?).should be_false
+    end
+    it "should return false if rackspace_region is nil" do
+      subject.rackspace_region = nil
+      subject.send(:lon_region?).should be_false
+    end
+    it "should return false if rackspace_region is :ord" do
+      subject.rackspace_region = :ord
+      subject.send(:lon_region?).should be_false
+    end
+    it "should return true if rackspace_region is 'lon'" do
+      subject.rackspace_region = 'lon'
+      subject.send(:lon_region?).should be_true
+    end
+    it "should return true if rackspace_Region is :lon" do
+      subject.rackspace_region = :lon
+      subject.send(:lon_region?).should be_true
     end
   end
 end


### PR DESCRIPTION
 By default it will select the global endpoint for all regions with the exception of London. If London region is selected, the UK authentication endpoint will be selected. 

TLDR UK cloud support!
