### PR TITLE
adding ability to specify disk_config in knife configuration file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ vagrant will authenticate against the UK authentication endpoint.
   defaults to the name of the Vagrant machine (via `config.vm.define`), but
   can be overridden with this.
 * `username` - The username with which to access Rackspace.
+* `disk_config` - Disk Configuration  'AUTO' or 'MANUAL'
 
 These can be set like typical provider-specific configuration:
 

--- a/lib/vagrant-rackspace/action/create_server.rb
+++ b/lib/vagrant-rackspace/action/create_server.rb
@@ -44,6 +44,7 @@ module VagrantPlugins
           env[:ui].info(I18n.t("vagrant_rackspace.launching_server"))
           env[:ui].info(" -- Flavor: #{flavor.name}")
           env[:ui].info(" -- Image: #{image.name}")
+          env[:ui].info(" -- Disk Config: #{config.disk_config}") if config.disk_config
           env[:ui].info(" -- Name: #{server_name}")
 
           # Build the options for launching...
@@ -58,6 +59,7 @@ module VagrantPlugins
               }
             ]
           }
+          options[:disk_config] = config.disk_config if config.disk_config
 
           # Create the server
           server = env[:rackspace_compute].servers.create(options)

--- a/lib/vagrant-rackspace/config.rb
+++ b/lib/vagrant-rackspace/config.rb
@@ -69,6 +69,18 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :username
 
+       # The disk configuration value.
+       #   * AUTO -   The server is built with a single partition the size of the target flavor disk. The file system is automatically adjusted to fit the entire partition.
+       #              This keeps things simple and automated. AUTO is valid only for images and servers with a single partition that use the EXT3 file system.
+       #              This is the default setting for applicable Rackspace base images.
+       #
+       #   * MANUAL - The server is built using whatever partition scheme and file system is in the source image. If the target flavor disk is larger,
+       #              the remaining disk space is left unpartitioned. This enables images to have non-EXT3 file systems, multiple partitions,
+       #              and so on, and enables you to manage the disk configuration.
+       #
+       # This defaults to MANUAL
+      attr_accessor :disk_config
+
       def initialize
         @api_key  = UNSET_VALUE
         @rackspace_region = UNSET_VALUE
@@ -80,6 +92,7 @@ module VagrantPlugins
         @rackconnect = UNSET_VALUE
         @server_name = UNSET_VALUE
         @username = UNSET_VALUE
+        @disk_config = UNSET_VALUE
       end
 
       def finalize!
@@ -92,6 +105,7 @@ module VagrantPlugins
         @rackconnect = nil if @rackconnect == UNSET_VALUE
         @server_name = nil if @server_name == UNSET_VALUE
         @username = nil if @username == UNSET_VALUE
+        @disk_config = nil if @disk_config == UNSET_VALUE
 
         if @public_key_path == UNSET_VALUE
           @public_key_path = Vagrant.source_root.join("keys/vagrant.pub")

--- a/spec/vagrant-rackspace/config_spec.rb
+++ b/spec/vagrant-rackspace/config_spec.rb
@@ -21,6 +21,7 @@ describe VagrantPlugins::Rackspace::Config do
     its(:rackconnect) { should be_nil }
     its(:server_name) { should be_nil }
     its(:username) { should be_nil }
+    its(:disk_config) { should be_nil }
   end
 
   describe "overriding defaults" do
@@ -33,6 +34,7 @@ describe VagrantPlugins::Rackspace::Config do
       :public_key_path,
       :rackconnect,
       :server_name,
+      :disk_config,
       :username].each do |attribute|
       it "should not default #{attribute} if overridden" do
         subject.send("#{attribute}=".to_sym, "foo")


### PR DESCRIPTION
This pull request adds support for specifying a cloud server's disk mode thereby satisfying issue https://github.com/mitchellh/vagrant-rackspace/issues/19
