### PR TITLE
Detect invalid configuration keys

### DIFF
--- a/lib/vagrant-rackspace/config.rb
+++ b/lib/vagrant-rackspace/config.rb
@@ -154,7 +154,7 @@ module VagrantPlugins
       end
 
       def validate(machine)
-        errors = []
+        errors = _detected_errors
 
         errors << I18n.t("vagrant_rackspace.config.api_key_required") if !@api_key
         errors << I18n.t("vagrant_rackspace.config.username_required") if !@username

--- a/spec/vagrant-rackspace/config_spec.rb
+++ b/spec/vagrant-rackspace/config_spec.rb
@@ -81,6 +81,16 @@ describe VagrantPlugins::Rackspace::Config do
       end
     end
 
+    context "with invalid key" do
+      it "should raise an error" do
+        subject.nonsense1 = true
+        subject.nonsense2 = false
+        I18n.should_receive(:t).with('vagrant.config.common.bad_field',
+          { :fields => 'nonsense1, nonsense2' })
+        .and_return error_message
+        validation_errors.first.should == error_message
+      end
+    end
     context "with good values" do
       it "should validate" do
         validation_errors.should be_empty


### PR DESCRIPTION
This patch makes it so incorrect keys are detected and treated as errors.  For example, given:

``` ruby
...
  config.vm.provider :rackspace do |rs|
    rs.username = ENV['RAX_USERNAME']
    rs.api_key  = ENV['RAX_API_KEY']
    rs.region = :syd
  end
...
```

Previously, when you ran `vagrant up --provider rackspace` it would ignore the unknown key, and start VM using the default region (likely :dfw).

With this patch you will get an error:

> RackSpace Provider:
> - The following settings don't exist: region

Note: it is implemented by using the [Config#_detected_errors](http://rubydoc.info/github/mitchellh/vagrant/Vagrant/Plugin/V2/Config#_detected_errors-instance_method).  The method isn't mentioned in the plugin validation documentation, but is commonly used by other plugins and providers.
