### PR TITLE
Fix Vagrant 1.4 compatibility and support multiple SSH keys

### DIFF
--- a/lib/vagrant-rackspace/action/sync_folders.rb
+++ b/lib/vagrant-rackspace/action/sync_folders.rb
@@ -48,7 +48,7 @@ module VagrantPlugins
               "rsync", "--verbose", "--archive", "-z",
               "--cvs-exclude", 
               "--exclude", ".hg/",
-              "-e", "ssh -p #{ssh_info[:port]} -i '#{ssh_info[:private_key_path]}' -o StrictHostKeyChecking=no",
+              "-e", "ssh -p #{ssh_info[:port]} -o StrictHostKeyChecking=no #{ssh_key_options(ssh_info)}",
               hostpath,
               "#{ssh_info[:username]}@#{ssh_info[:host]}:#{guestpath}"]
 
@@ -70,6 +70,13 @@ module VagrantPlugins
                 :stderr => r.stderr
             end
           end
+        end
+
+        private
+ 
+        def ssh_key_options(ssh_info)
+          # Ensure that `private_key_path` is an Array (for Vagrant < 1.4)
+          Array(ssh_info[:private_key_path]).map { |path| "-i '#{path}' " }.join
         end
       end
     end


### PR DESCRIPTION
Vagrant 1.4.0 added support for multiple SSH keys
(mitchellh/vagrant#907)
and changed `private_key_path` to an Array.

This commit ensures we always handle it as array to keep compatible with
both old and new Vagrant versions. Also pass all of the specified keys
to rsync/ssh command.
