### PR TITLE
Add chef client/node cleanup

### DIFF
--- a/lib/vagrant-rackspace/action.rb
+++ b/lib/vagrant-rackspace/action.rb
@@ -20,6 +20,7 @@ module VagrantPlugins
 
             b2.use ConnectRackspace
             b2.use DeleteServer
+            b2.use ProvisionerCleanup if defined?(ProvisionerCleanup)
           end
         end
       end


### PR DESCRIPTION
Enable vagrant to cleanup chef node and client from chef server.

Copies patch submitted to vagrant-aws plugin - https://github.com/tmatilai/vagrant-aws/commit/5ffb091ee139c80083ecf6208a786c6bd1d0bc25
