### PR TITLE
updating documentation to include information about rackconnect. Removing

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,18 @@ Note that normally a lot of this boilerplate is encoded within the box
 file, but the box file used for the quick start, the "dummy" box, has
 no preconfigured defaults.
 
+### Flavors / Images
+
+ To determine what flavors and images are avliable in your region refer to the [Custom Commands](#custom-commands) section.
+
+### RackConnect
+
+If you are using RackConnect with vagrant, you will need to add the following line to the `config.vm.provider` section to prevent timeouts.
+
+  ```
+  rs.rackconnect = true
+  ```
+
 ## Custom Commands
 
 The plugin includes several Rackspace-specific vagrant commands.  You can get the
@@ -153,29 +165,6 @@ Vagrant.configure("2") do |config|
   end
 end
 ```
-
-### Flavors
-
-As of February 2, 2014, the available flavor names are:
-
-* 512MB Standard Instance
-* 1GB Standard Instance
-* 2GB Standard Instance
-* 4GB Standard Instance
-* 8GB Standard Instance
-* 15GB Standard Instance
-* 30GB Standard Instance
-* 1 GB Performance
-* 2 GB Performance
-* 4 GB Performance
-* 8 GB Performance
-* 120 GB Performance
-* 15 GB Performance
-* 30 GB Performance
-* 60 GB Performance
-* 90 GB Performance
-
-Please note that the standard instances are deprecated in favor of our performance flavors.
 
 ## Networks
 


### PR DESCRIPTION
flavor list as vagrant now supports listing these via the command line.
