### PR TITLE
rackspace_region has to be set to avoid warnings

### DIFF
--- a/lib/vagrant-rackspace/config.rb
+++ b/lib/vagrant-rackspace/config.rb
@@ -124,7 +124,7 @@ module VagrantPlugins
 
       def finalize!
         @api_key  = nil if @api_key == UNSET_VALUE
-        @rackspace_region = nil if @rackspace_region == UNSET_VALUE
+        @rackspace_region = :dwf if @rackspace_region == UNSET_VALUE
         @rackspace_compute_url = nil if @rackspace_compute_url == UNSET_VALUE
         @rackspace_auth_url = nil if @rackspace_auth_url == UNSET_VALUE
         @flavor   = /512MB/ if @flavor == UNSET_VALUE

--- a/spec/vagrant-rackspace/config_spec.rb
+++ b/spec/vagrant-rackspace/config_spec.rb
@@ -12,7 +12,7 @@ describe VagrantPlugins::Rackspace::Config do
     end
 
     its(:api_key)  { should be_nil }
-    its(:rackspace_region) { should be_nil }
+    its(:rackspace_region) { :dfw }
     its(:rackspace_compute_url) { should be_nil }
     its(:rackspace_auth_url) { should be_nil }
     its(:flavor)   { should eq(/512MB/) }


### PR DESCRIPTION
Set rackspace_region to :dfw by default.

```
[fog][DEPRECATION] Default region support will be
removed in an upcoming release. Please switch to
manually setting your endpoint. This requires
settng the :rackspace_region option
```
