### PR TITLE
copy symlinks when syncing folders

### DIFF
--- a/lib/vagrant-rackspace/action/sync_folders.rb
+++ b/lib/vagrant-rackspace/action/sync_folders.rb
@@ -54,7 +54,7 @@ module VagrantPlugins
             # .hg/ to exclude list as that isn't covered in
             # --cvs-exclude
             command = [
-              "rsync", "--verbose", "--archive", "-z",
+              "rsync", "--verbose", "--archive", "-z", "-L",
               "--cvs-exclude", 
               "--exclude", ".hg/",
               *includes,


### PR DESCRIPTION
Instead of copying symlinks when syncing folders I think they should
be copied as files using the parameter -L of rsync.

```
When symlinks are encountered, the item that they point to (the referent)
is copied, rather than the symlink.
```
