### PR TITLE
added subcommand keypairs to list SSH key pairs

### DIFF
--- a/lib/vagrant-rackspace/action.rb
+++ b/lib/vagrant-rackspace/action.rb
@@ -142,6 +142,13 @@ module VagrantPlugins
         end
       end
 
+      def self.action_list_keypairs
+        Vagrant::Action::Builder.new.tap do |b|
+          b.use ConnectRackspace
+          b.use ListKeyPairs
+        end
+      end
+
       # The autoload farm
       action_root = Pathname.new(File.expand_path("../action", __FILE__))
       autoload :ConnectRackspace, action_root.join("connect_rackspace")
@@ -156,6 +163,7 @@ module VagrantPlugins
       autoload :CreateImage, action_root.join("create_image")
       autoload :ListImages, action_root.join("list_images")
       autoload :ListFlavors, action_root.join("list_flavors")
+      autoload :ListKeyPairs, action_root.join("list_keypairs")
     end
   end
 end

--- a/lib/vagrant-rackspace/action/list_keypairs.rb
+++ b/lib/vagrant-rackspace/action/list_keypairs.rb
@@ -1,0 +1,20 @@
+module VagrantPlugins
+  module Rackspace
+    module Action
+      class ListKeyPairs
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          compute_service = env[:rackspace_compute]
+          env[:ui].info ('%s' % ['KeyPair Name'])
+          compute_service.key_pairs.sort_by(&:name).each do |keypair|
+            env[:ui].info ('%s' % [keypair.name])
+          end
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-rackspace/command/keypairs.rb
+++ b/lib/vagrant-rackspace/command/keypairs.rb
@@ -1,0 +1,21 @@
+module VagrantPlugins
+  module Rackspace
+    module Command
+      class KeyPairs < Vagrant.plugin("2", :command)
+        def execute
+          options = {}
+          opts = OptionParser.new do |o|
+            o.banner = "Usage: vagrant rackspace keypairs [options]"
+          end
+
+          argv = parse_options(opts)
+          return if !argv
+
+          with_target_vms(argv, :provider => :rackspace) do |machine|
+            machine.action('list_keypairs')
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-rackspace/command/root.rb
+++ b/lib/vagrant-rackspace/command/root.rb
@@ -20,6 +20,10 @@ module VagrantPlugins
             require File.expand_path("../flavors", __FILE__)
             Flavors
           end
+          @subcommands.register(:keypairs) do
+            require File.expand_path("../keypairs", __FILE__)
+            KeyPairs
+          end
 
           super(argv, env)
         end


### PR DESCRIPTION
Example output of this subcommand (one keypair with the name vagrant
is available on Rackspace Servers):

```
$ vagrant rackspace keypairs
==> default: KeyPair Name
==> default: vagrant
```
