### PR TITLE
Fix breaking sub reference on windows

### DIFF
--- a/lib/vagrant-rackspace/action/sync_folders.rb
+++ b/lib/vagrant-rackspace/action/sync_folders.rb
@@ -32,7 +32,7 @@ module VagrantPlugins
             
             # If on Windows, modify the path to work with cygwin rsync
             if @host_os =~ /mswin|mingw|cygwin/
-              hostpath = hostpath.sub(/^([A-Za-z]):\//, "/cygdrive/#{$1.downcase}/")
+              hostpath = hostpath.sub(/^([A-Za-z]):\//) { "/cygdrive/#{$1.downcase}/" }
             end
 
             env[:ui].info(I18n.t("vagrant_rackspace.rsync_folder",


### PR DESCRIPTION
I'm not a ruby guy but before making this change this line was throwing the error `undefined method downcase for nil`. This syntax change makes it work.
