### PR TITLE
support for provisioning unlisted images

### DIFF
--- a/lib/vagrant-rackspace/action/create_server.rb
+++ b/lib/vagrant-rackspace/action/create_server.rb
@@ -27,6 +27,9 @@ module VagrantPlugins
           # Find the image
           env[:ui].info(I18n.t("vagrant_rackspace.finding_image"))
           image = find_matching(env[:rackspace_compute].images.all, config.image)
+          if not image
+            image = env[:rackspace_compute].images.get config.image
+          end
           raise Errors::NoMatchingImage if !image
 
           # Figure out the name for the server


### PR DESCRIPTION
If the image isn't found in the list-collection, try to look it up directly using the `get` method. This allows provisioning "unlisted" images by ID, such as those indicated in the [CoreOS documentation](https://coreos.com/docs/running-coreos/cloud-providers/rackspace/).
