### PR TITLE
Use builtin synced folders if available

### DIFF
--- a/lib/vagrant-rackspace/action.rb
+++ b/lib/vagrant-rackspace/action.rb
@@ -36,7 +36,11 @@ module VagrantPlugins
             end
 
             b2.use Provision
-            b2.use SyncFolders
+            if defined?(SyncedFolders)
+              b2.use SyncedFolders
+            else
+              b2.use SyncFolders
+            end
           end
         end
       end
@@ -102,7 +106,11 @@ module VagrantPlugins
 
             b2.use ConnectRackspace
             b2.use Provision
-            b2.use SyncFolders
+            if defined?(SyncedFolders)
+              b2.use SyncedFolders
+            else
+              b2.use SyncFolders
+            end
             b2.use CreateServer
           end
         end


### PR DESCRIPTION
I'm proposing this solution for using core synced folder plugins without dropping the legacy rsync code for people that are still on Vagrant < 1.4.

In my opinion such a solution could help fixing many issues related to rsync and could also make [Windows support](https://github.com/mitchellh/vagrant-rackspace/pull/93) easier to achieve.

Please note that I've tested the modification only on Vagrant 1.6

Thanks in advance for your attention.
