### PR TITLE
Set root or Administrator password via admin_pass

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,6 +14,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "dummy"
   config.vm.provider :rackspace do |rs|
     rs.username = ENV['RAX_USERNAME']
+    rs.admin_pass = ENV['VAGRANT_ADMIN_PASS']
     rs.api_key  = ENV['RAX_API_KEY']
     rs.flavor   = /1 GB Performance/
     rs.image    = /Ubuntu/

--- a/lib/vagrant-rackspace/action/create_server.rb
+++ b/lib/vagrant-rackspace/action/create_server.rb
@@ -59,6 +59,10 @@ module VagrantPlugins
             :metadata    => config.metadata
           }
 
+          if config.admin_pass
+            options[:password] = config.admin_pass
+          end
+
           if config.user_data
             options[:user_data] = File.read(config.user_data)
           end

--- a/lib/vagrant-rackspace/config.rb
+++ b/lib/vagrant-rackspace/config.rb
@@ -112,6 +112,13 @@ module VagrantPlugins
       # @return [Array]
       attr_accessor :rsync_includes
 
+      # Password to set for root (on Linux) or Administrator (on Windows)
+      # A random password will be generated if admin_pass is not set or
+      # does not meet the password requirements of the operating system.
+      #
+      # @return [String]
+      attr_accessor :admin_pass
+
       # Default Rackspace Cloud Network IDs
       SERVICE_NET_ID = '11111111-1111-1111-1111-111111111111'
       PUBLIC_NET_ID = '00000000-0000-0000-0000-000000000000'

--- a/spec/vagrant-rackspace/config_spec.rb
+++ b/spec/vagrant-rackspace/config_spec.rb
@@ -24,6 +24,7 @@ describe VagrantPlugins::Rackspace::Config do
     its(:disk_config) { should be_nil }
     its(:networks) { should be_nil }
     its(:rsync_includes) { should be_nil }
+    its(:admin_pass)  { should be_nil }
   end
 
   describe "overriding defaults" do
@@ -37,7 +38,8 @@ describe VagrantPlugins::Rackspace::Config do
       :rackconnect,
       :server_name,
       :disk_config,
-      :username].each do |attribute|
+      :username,
+      :admin_pass].each do |attribute|
       it "should not default #{attribute} if overridden" do
         subject.send("#{attribute}=".to_sym, "foo")
         subject.finalize!


### PR DESCRIPTION
Allow setting the admin_pass. This is especially useful on Windows since Vagrant's winrm communicator only support basic auth right now, so we need an alternative to using ssh keys.

Since the randomly generated admin_pass is never displayed or stored, pre-selecting a password via admin_pass is the only way you'll be able to connect to a windows server.

Fixing the 2nd of 3 blockers found on the windows spike (#93).
