### PR TITLE
adding sync folders deprecation 

### DIFF
--- a/lib/vagrant-rackspace/action/sync_folders.rb
+++ b/lib/vagrant-rackspace/action/sync_folders.rb
@@ -16,6 +16,7 @@ module VagrantPlugins
 
         def call(env)
           @app.call(env)
+          env[:ui].warn(I18n.t("vagrant_rackspace.sync_folders"))
 
           ssh_info = env[:machine].ssh_info
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -36,6 +36,9 @@ en:
       Warning! The Rackspace provider doesn't support any of the Vagrant
       high-level network configurations (`config.vm.network`). They
       will be silently ignored.
+    sync_folders: |-
+        Rackspace support for Vagrant 1.3 has been deprecated. Please
+        upgrade to the latest version of vagrant for continued support. 
 
     config:
       api_key_required: |-


### PR DESCRIPTION
PR https://github.com/mitchellh/vagrant-rackspace/pull/104 allows users to use the new syncing features built into vagrant 1.4+ while falling back to the builtin Rackspace sync support for older versions of vagrant.

This PR adds a deprecation method to encourage users to upgrade vagrant.
