### PR TITLE
Fix uninitialized constant error.

### DIFF
--- a/lib/vagrant-rackspace/action.rb
+++ b/lib/vagrant-rackspace/action.rb
@@ -12,15 +12,22 @@ module VagrantPlugins
       def self.action_destroy
         Vagrant::Action::Builder.new.tap do |b|
           b.use ConfigValidate
-          b.use Call, IsCreated do |env, b2|
+          b.use Call, IsCreated do |env, b1|
             if !env[:result]
-              b2.use MessageNotCreated
+              b1.use MessageNotCreated
               next
             end
 
-            b2.use ConnectRackspace
-            b2.use DeleteServer
-            b2.use ProvisionerCleanup if defined?(ProvisionerCleanup)
+            b1.use Call, DestroyConfirm do |env1, b2|
+              if env1[:result]
+                b2.use ConnectRackspace
+                b2.use DeleteServer
+                b2.use ProvisionerCleanup if defined?(ProvisionerCleanup)
+              else
+                b2.use Message, I18n.t("vagrant_rackspace.will_not_destroy")
+                next
+              end
+            end
           end
         end
       end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -36,6 +36,8 @@ en:
       Warning! The Rackspace provider doesn't support any of the Vagrant
       high-level network configurations (`config.vm.network`). They
       will be silently ignored.
+    will_not_destroy: |-
+      The server will not be deleted.
     sync_folders: |-
         Rackspace support for Vagrant 1.3 has been deprecated. Please
         upgrade to the latest version of vagrant for continued support. 


### PR DESCRIPTION
The plug-in was error-ing out because no message was initialized for destroy
skip action.

See my comment on the previous pull request:

mitchellh/vagrant-rackspace#116
