### PR TITLE
Clarified README.md about setting up and sourcing env variables for best practice of keeping api keys private

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Vagrant.configure("2") do |config|
   # config.vm.box = "dummy"
 
   config.vm.provider :rackspace do |rs|
-    rs.username         = ENV['RAX_USR']
-    rs.api_key          = ENV['RAX_KEY']
+    rs.username         = "your-rackspace-user-name"
+    rs.api_key          = "your-rackspace-api-key"
     rs.rackspace_region = :ord
     rs.flavor           = /1 GB Performance/
     rs.image            = /Ubuntu/
@@ -50,7 +50,7 @@ Vagrant.configure("2") do |config|
 end
 ```
 
-Optionally, set up environment variables on your shell, for frequently used parameters,
+Set up environment variables on your shell, for frequently used parameters,
 especially your username and api key, if you plan to share your vagrant files. this 
 will prevent accidentally divulging your keys.
 
@@ -68,7 +68,7 @@ will prevent accidentally divulging your keys.
         export API_KEY="your-rackspace-api-key"
 ```
 
-Then, your vagrant file should look like this:
+Change your vagrant file to source your environment. It should look like this:
 
 ```ruby
 Vagrant.configure("2") do |config|

--- a/README.md
+++ b/README.md
@@ -40,9 +40,47 @@ Vagrant.configure("2") do |config|
   # config.vm.box = "dummy"
 
   config.vm.provider :rackspace do |rs|
-    rs.username         = "YOUR USERNAME"
-    rs.api_key          = "YOUR API KEY"
+    rs.username         = ENV[RAX_USR]
+    rs.api_key          = ENV[RAX_KEY]
     rs.rackspace_region = :ord
+    rs.flavor           = /1 GB Performance/
+    rs.image            = /Ubuntu/
+    rs.metadata         = {"key" => "value"}       # optional
+  end
+end
+```
+
+Optionally, set up environment variables on your shell, for frequently used parameters,
+especially your username and api key, if you plan to share your vagrant files. this 
+will prevent accidentally divulging your keys.
+
+```tcsh
+    .tcshrc:
+        setenv RAX_USR "your-rackspace-user-name"
+        setenv RAX_REG ":region"
+        setenv API_KEY "your-rackspace-api-key"
+```
+
+
+```bash
+    .bashrc or .zshrc
+        export RAX_USR="your-rackspace-user-name"
+        export RAX_REG=":region"
+        export API_KEY="your-rackspace-api-key"
+```
+
+Then, your vagrant file should look like this:
+
+
+```ruby
+Vagrant.configure("2") do |config|
+  # The box is optional in newer versions of Vagrant
+  # config.vm.box = "dummy"
+
+  config.vm.provider :rackspace do |rs|
+    rs.username         = ENV[RAX_USR]
+    rs.api_key          = ENV[RAX_KEY]
+    rs.rackspace_region = ENV[RAX_REG]
     rs.flavor           = /1 GB Performance/
     rs.image            = /Ubuntu/
     rs.metadata         = {"key" => "value"}       # optional
@@ -86,8 +124,8 @@ Vagrant.configure("2") do |config|
   config.ssh.pty = true
 
   config.vm.provider :rackspace do |rs|
-    rs.username = "YOUR USERNAME"
-    rs.api_key  = "YOUR API KEY"
+    rs.username = ENV[RAX_USR]
+    rs.api_key  = ENV[RAX_KEY]
     rs.flavor   = /1 GB Performance/
     rs.image    = /^CentOS/
     rs.init_script = 'sed -i\'.bk\' -e \'s/^\(Defaults\s\+requiretty\)/# \1/\' /etc/sudoers'
@@ -111,8 +149,8 @@ Vagrant.configure("2") do |config|
   config.vm.box = "dummy"
 
   config.vm.provider :rackspace do |rs|
-    rs.username = "YOUR USERNAME"
-    rs.api_key  = "YOUR API KEY"
+    rs.username = ENV[RAX_USR]
+    rs.api_key  = ENV[RAX_KEY]
     rs.flavor   = /1 GB Performance/
     rs.image    = 'Windows Server 2012'
     rs.init_script = File.read 'bootstrap.cmd'

--- a/README.md
+++ b/README.md
@@ -56,14 +56,14 @@ will prevent accidentally divulging your keys.
 
 ```tcsh
     .tcshrc:
-        setenv RAX_USR "your-rackspace-user-name"
+        setenv RAX_USERNAME "your-rackspace-user-name"
         setenv RAX_REG ":region"
         setenv API_KEY "your-rackspace-api-key"
 ```
 
 ```bash
     .bashrc or .zshrc
-        export RAX_USR="your-rackspace-user-name"
+        export RAX_USERNAME="your-rackspace-user-name"
         export RAX_REG=":region"
         export API_KEY="your-rackspace-api-key"
 ```
@@ -76,8 +76,8 @@ Vagrant.configure("2") do |config|
   # config.vm.box = "dummy"
 
   config.vm.provider :rackspace do |rs|
-    rs.username         = ENV['RAX_USR']
-    rs.api_key          = ENV['RAX_KEY']
+    rs.username         = ENV['RAX_USERNAME']
+    rs.api_key          = ENV['RAX_API_KEY']
     rs.rackspace_region = ENV['RAX_REG']
     rs.flavor           = /1 GB Performance/
     rs.image            = /Ubuntu/
@@ -122,8 +122,8 @@ Vagrant.configure("2") do |config|
   config.ssh.pty = true
 
   config.vm.provider :rackspace do |rs|
-    rs.username = ENV['RAX_USR']
-    rs.api_key  = ENV['RAX_KEY']
+    rs.username = ENV['RAX_USERNAME']
+    rs.api_key  = ENV['RAX_API_KEY']
     rs.flavor   = /1 GB Performance/
     rs.image    = /^CentOS/
     rs.init_script = 'sed -i\'.bk\' -e \'s/^\(Defaults\s\+requiretty\)/# \1/\' /etc/sudoers'
@@ -147,8 +147,8 @@ Vagrant.configure("2") do |config|
   config.vm.box = "dummy"
 
   config.vm.provider :rackspace do |rs|
-    rs.username = ENV['RAX_USR']
-    rs.api_key  = ENV['RAX_KEY']
+    rs.username = ENV['RAX_USERNAME']
+    rs.api_key  = ENV['RAX_API_KEY']
     rs.flavor   = /1 GB Performance/
     rs.image    = 'Windows Server 2012'
     rs.init_script = File.read 'bootstrap.cmd'
@@ -166,7 +166,7 @@ common parameters from your shell environment, for example:
 *Environment*
 ```tcsh
     .tcshrc:
-        setenv RAX_USR "your-rackspace-user-name"
+        setenv RAX_USERNAME "your-rackspace-user-name"
         setenv RAX_REG ":region"
         setenv API_KEY "your-rackspace-api-key"
         setenv VAGRANT_ADMIN_PASSWORD "your-vagrant-admin-password"
@@ -174,7 +174,7 @@ common parameters from your shell environment, for example:
 
 ```bash
     .bashrc or .zshrc
-        export RAX_USR="your-rackspace-user-name"
+        export RAX_USERNAME="your-rackspace-user-name"
         export RAX_REG=":region"
         export API_KEY="your-rackspace-api-key"
         export VAGRANT_ADMIN_PASSWORD="your-vagrant-admin-password"
@@ -194,9 +194,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define :ubuntu do |ubuntu|
     ubuntu.ssh.private_key_path = '~/.ssh/id_rsa'
     ubuntu.vm.provider :rackspace do |rs|
-      rs.username = ENV['RAX_USR']
+      rs.username = ENV['RAX_USERNAME']
       rs.admin_password = ENV['VAGRANT_ADMIN_PASSWORD']
-      rs.api_key  = ENV['RAX_KEY']
+      rs.api_key  = ENV['RAX_API_KEY']
       rs.flavor   = /1 GB Performance/
       rs.image    = /Ubuntu/
       rs.rackspace_region = :iad
@@ -208,9 +208,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     centos.ssh.private_key_path = '~/.ssh/id_rsa'
     centos.ssh.pty = true
     centos.vm.provider :rackspace do |rs|
-      rs.username = ENV['RAX_USR']
+      rs.username = ENV['RAX_USERNAME']
       rs.admin_password = ENV['VAGRANT_ADMIN_PASSWORD']
-      rs.api_key  = ENV['RAX_KEY']
+      rs.api_key  = ENV['RAX_API_KEY']
       rs.flavor   = /1 GB Performance/
       rs.image    = /^CentOS/ # Don't match OnMetal - CentOS
       rs.rackspace_region = :iad
@@ -232,8 +232,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
     windows.vm.synced_folder ".", "/vagrant", disabled: true
     windows.vm.provider :rackspace do |rs|
-      rs.username = ENV['RAX_USR']
-      rs.api_key  = ENV['RAX_KEY']
+      rs.username = ENV['RAX_USERNAME']
+      rs.api_key  = ENV['RAX_API_KEY']
       rs.admin_password = ENV['VAGRANT_ADMIN_PASSWORD']
       rs.flavor   = /2 GB Performance/
       rs.image    = 'Windows Server 2012'
@@ -333,8 +333,8 @@ Vagrant.configure("2") do |config|
   # ... other stuff
 
   config.vm.provider :rackspace do |rs|
-    rs.username = "mitchellh"
-    rs.api_key  = "foobarbaz"
+    rs.username = ENV['RAX_USERNAME']
+    rs.api_key  = ENV['RAX_API_KEY']
   end
 end
 ```
@@ -352,8 +352,8 @@ However, you may attach a VM to an isolated [Cloud Network](http://www.rackspace
 
 ```ruby
 config.vm.provider :rackspace do |rs|
-  rs.username = "mitchellh"
-  rs.api_key  = "foobarbaz"
+  rs.username = ENV['RAX_USERNAME']
+  rs.api_key  = ENV['RAX_API_KEY']
   rs.network '443aff42-be57-effb-ad30-c097c1e4503f'
   rs.network '5e738e11-def2-4a75-ad1e-05bbe3b49efe'
   rs.network :service_net, :attached => false

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Vagrant.configure("2") do |config|
   # config.vm.box = "dummy"
 
   config.vm.provider :rackspace do |rs|
-    rs.username         = ENV[RAX_USR]
-    rs.api_key          = ENV[RAX_KEY]
+    rs.username         = ENV['RAX_USR']
+    rs.api_key          = ENV['RAX_KEY']
     rs.rackspace_region = :ord
     rs.flavor           = /1 GB Performance/
     rs.image            = /Ubuntu/
@@ -61,7 +61,6 @@ will prevent accidentally divulging your keys.
         setenv API_KEY "your-rackspace-api-key"
 ```
 
-
 ```bash
     .bashrc or .zshrc
         export RAX_USR="your-rackspace-user-name"
@@ -71,16 +70,15 @@ will prevent accidentally divulging your keys.
 
 Then, your vagrant file should look like this:
 
-
 ```ruby
 Vagrant.configure("2") do |config|
   # The box is optional in newer versions of Vagrant
   # config.vm.box = "dummy"
 
   config.vm.provider :rackspace do |rs|
-    rs.username         = ENV[RAX_USR]
-    rs.api_key          = ENV[RAX_KEY]
-    rs.rackspace_region = ENV[RAX_REG]
+    rs.username         = ENV['RAX_USR']
+    rs.api_key          = ENV['RAX_KEY']
+    rs.rackspace_region = ENV['RAX_REG']
     rs.flavor           = /1 GB Performance/
     rs.image            = /Ubuntu/
     rs.metadata         = {"key" => "value"}       # optional
@@ -124,8 +122,8 @@ Vagrant.configure("2") do |config|
   config.ssh.pty = true
 
   config.vm.provider :rackspace do |rs|
-    rs.username = ENV[RAX_USR]
-    rs.api_key  = ENV[RAX_KEY]
+    rs.username = ENV['RAX_USR']
+    rs.api_key  = ENV['RAX_KEY']
     rs.flavor   = /1 GB Performance/
     rs.image    = /^CentOS/
     rs.init_script = 'sed -i\'.bk\' -e \'s/^\(Defaults\s\+requiretty\)/# \1/\' /etc/sudoers'
@@ -149,8 +147,8 @@ Vagrant.configure("2") do |config|
   config.vm.box = "dummy"
 
   config.vm.provider :rackspace do |rs|
-    rs.username = ENV[RAX_USR]
-    rs.api_key  = ENV[RAX_KEY]
+    rs.username = ENV['RAX_USR']
+    rs.api_key  = ENV['RAX_KEY']
     rs.flavor   = /1 GB Performance/
     rs.image    = 'Windows Server 2012'
     rs.init_script = File.read 'bootstrap.cmd'
@@ -162,8 +160,28 @@ You can get a sample [bootstrap.cmd](bootstrap.cmd) file from this repo.
 
 ### Parallel, multi-machine setup
 
-You can define multiple machines in a single Vagrant file, for example:
+You can define multiple machines in a single Vagrant file, sourcing 
+common parameters from your shell environment, for example:
 
+*Environment*
+```tcsh
+    .tcshrc:
+        setenv RAX_USR "your-rackspace-user-name"
+        setenv RAX_REG ":region"
+        setenv API_KEY "your-rackspace-api-key"
+        setenv VAGRANT_ADMIN_PASSWORD "your-vagrant-admin-password"
+```
+
+```bash
+    .bashrc or .zshrc
+        export RAX_USR="your-rackspace-user-name"
+        export RAX_REG=":region"
+        export API_KEY="your-rackspace-api-key"
+        export VAGRANT_ADMIN_PASSWORD="your-vagrant-admin-password"
+```
+
+
+*Vagrantfile:*
 ```ruby
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # All Vagrant configuration is done here. The most common configuration
@@ -176,9 +194,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.define :ubuntu do |ubuntu|
     ubuntu.ssh.private_key_path = '~/.ssh/id_rsa'
     ubuntu.vm.provider :rackspace do |rs|
-      rs.username = ENV['RAX_USERNAME']
+      rs.username = ENV['RAX_USR']
       rs.admin_password = ENV['VAGRANT_ADMIN_PASSWORD']
-      rs.api_key  = ENV['RAX_API_KEY']
+      rs.api_key  = ENV['RAX_KEY']
       rs.flavor   = /1 GB Performance/
       rs.image    = /Ubuntu/
       rs.rackspace_region = :iad
@@ -190,9 +208,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     centos.ssh.private_key_path = '~/.ssh/id_rsa'
     centos.ssh.pty = true
     centos.vm.provider :rackspace do |rs|
-      rs.username = ENV['RAX_USERNAME']
+      rs.username = ENV['RAX_USR']
       rs.admin_password = ENV['VAGRANT_ADMIN_PASSWORD']
-      rs.api_key  = ENV['RAX_API_KEY']
+      rs.api_key  = ENV['RAX_KEY']
       rs.flavor   = /1 GB Performance/
       rs.image    = /^CentOS/ # Don't match OnMetal - CentOS
       rs.rackspace_region = :iad
@@ -214,12 +232,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
     windows.vm.synced_folder ".", "/vagrant", disabled: true
     windows.vm.provider :rackspace do |rs|
-      rs.username = ENV['RAX_USERNAME']
-      rs.api_key  = ENV['RAX_API_KEY']
+      rs.username = ENV['RAX_USR']
+      rs.api_key  = ENV['RAX_KEY']
       rs.admin_password = ENV['VAGRANT_ADMIN_PASSWORD']
       rs.flavor   = /2 GB Performance/
       rs.image    = 'Windows Server 2012'
-      rs.rackspace_region = ENV['RAX_REGION'] ||= 'dfw'
+      rs.rackspace_region = ENV['RAX_REG'] ||= 'dfw'
       rs.init_script = File.read 'bootstrap.cmd'
     end
   end


### PR DESCRIPTION
Some of us are less proficient in ruby, and it took me a while to figure out how to read my environment variable from the vagrant file. I'm a bit wiser for this, and hopefully it will save someone a bit of time.

Hopefully, also, it will prevent a couple of publicly spilled api keys...

Also, includes cleanly merged PR #134 

Changes to be committed:
        modified:   README.md