### PR TITLE
Allow specifying network name for communication with the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ vagrant will authenticate against the UK authentication endpoint.
 * `disk_config` - Disk Configuration  'AUTO' or 'MANUAL'
 * `metadata` - A set of key pair values that will be passed to the instance
   for configuration.
+* `network_name` - Network name to be usd for communicating with the server.
 
 These can be set like typical provider-specific configuration:
 

--- a/lib/vagrant-rackspace/action/read_ssh_info.rb
+++ b/lib/vagrant-rackspace/action/read_ssh_info.rb
@@ -29,12 +29,19 @@ module VagrantPlugins
             return nil
           end
 
+          server_ip_address = machine.provider_config.network_name ?
+            ip_address(server, machine.provider_config.network_name) : server.public_ip_address
+
           # Read the DNS info
           return {
-            :host => server.ipv4_address,
-            :port => 22,
-            :username => "root"
+            :host => machine.config.ssh.host ? machine.config.ssh.host : server_ip_address,
+            :port => machine.config.ssh.port ? machine.config.ssh.port : 22,
+            :username => machine.config.ssh.username ? machine.config.ssh.username : 'root'
           }
+        end
+
+        def ip_address(server, network_name)
+          server.addresses[network_name].select{|a| a["version"] == 4}[0]["addr"] rescue ''
         end
       end
     end

--- a/lib/vagrant-rackspace/config.rb
+++ b/lib/vagrant-rackspace/config.rb
@@ -130,6 +130,11 @@ module VagrantPlugins
       # @see http://docs.rackspace.com/servers/api/v2/cs-devguide/content/Server_Personality-d1e2543.html Server Personality
       attr_accessor :init_script
 
+      # Network name to be use for connecting to the server. Particularly useful in case public network is disabled.
+      #
+      # @return [String]
+      attr_accessor :network_name
+
       # Default Rackspace Cloud Network IDs
       SERVICE_NET_ID = '11111111-1111-1111-1111-111111111111'
       PUBLIC_NET_ID = '00000000-0000-0000-0000-000000000000'


### PR DESCRIPTION
Use machine ssh config values (port, host, username) for ssh_info action.
