### PR TITLE
Catch Excon::Error::Timeout error to avoid backtrace

### DIFF
--- a/lib/vagrant-rackspace/action/create_server.rb
+++ b/lib/vagrant-rackspace/action/create_server.rb
@@ -117,7 +117,7 @@ module VagrantPlugins
 
           # Wait for the server to finish building
           env[:ui].info(I18n.t("vagrant_rackspace.waiting_for_build"))
-          retryable(:on => Fog::Errors::TimeoutError, :tries => 200) do
+          retryable(:on => [Excon::Error::Timeout, Fog::Errors::TimeoutError], :tries => 200) do
             # If we're interrupted don't worry about waiting
             next if env[:interrupted]
 


### PR DESCRIPTION
Whats up, folks! I've been using Vagrant Rackspace for some time, but recently
Rackspace started timing out, things are slower there for some reason, excon is
timing out with:

```
Bringing machine 'f24' up with 'rackspace' provider...
==> f24: Finding flavor for server...
==> f24: Finding image for server...
==> f24: Launching a server with the following settings...
==> f24:  -- Flavor: 1GB Standard Instance
==> f24:  -- Image: Fedora 24 (PVHVM)
==> f24:  -- Name: foreman-f24.imagebuilderv2.theforeman.org
==> f24: Waiting for the server to be built...
==> f24: Progress: 10%/home/lzap/.vagrant.d/gems/2.2.5/gems/excon-0.54.0/lib/excon/socket.rb:267:in `select_with_timeout': read timeout reached (Excon::Error::Timeout)
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/excon-0.54.0/lib/excon/socket.rb:49:in `rescue in readline'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/excon-0.54.0/lib/excon/socket.rb:45:in `readline'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/excon-0.54.0/lib/excon/response.rb:63:in `parse'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/excon-0.54.0/lib/excon/middlewares/response_parser.rb:7:in `response_call'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/excon-0.54.0/lib/excon/connection.rb:388:in `response'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/excon-0.54.0/lib/excon/connection.rb:252:in `request'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/fog-core-1.43.0/lib/fog/core/connection.rb:81:in `request'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/fog-rackspace-0.1.2/lib/fog/rackspace/service.rb:42:in `request'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/fog-rackspace-0.1.2/lib/fog/rackspace/compute_v2.rb:164:in `request'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/fog-rackspace-0.1.2/lib/fog/rackspace/requests/compute_v2/get_server.rb:41:in `get_server'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/fog-rackspace-0.1.2/lib/fog/rackspace/models/compute_v2/servers.rb:56:in `get'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/fog-core-1.43.0/lib/fog/core/model.rb:43:in `reload'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/fog-core-1.43.0/lib/fog/core/model.rb:70:in `block in wait_for'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/fog-core-1.43.0/lib/fog/core/wait_for.rb:7:in `block in wait_for'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/fog-core-1.43.0/lib/fog/core/wait_for.rb:6:in `loop'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/fog-core-1.43.0/lib/fog/core/wait_for.rb:6:in `wait_for'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/fog-core-1.43.0/lib/fog/core/model.rb:69:in `wait_for'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/vagrant-rackspace-0.1.10/lib/vagrant-rackspace/action/create_server.rb:129:in `block in call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.9.1/lib/vagrant/util/retryable.rb:17:in `retryable'
        from /home/lzap/.vagrant.d/gems/2.2.5/gems/vagrant-rackspace-0.1.10/lib/vagrant-rackspace/action/create_server.rb:120:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.9.1/lib/vagrant/action/warden.rb:34:in `call'
```

This was discussed in https://github.com/mitchellh/vagrant-rackspace/issues/14

With this patch, everything works as expected (well slower but what can I do).